### PR TITLE
chore(deps): upgrade dependencies

### DIFF
--- a/diff.txt
+++ b/diff.txt
@@ -1,0 +1,477 @@
+diff --git a/package.json b/package.json
+index 684a751..41a199e 100644
+--- a/package.json
++++ b/package.json
+@@ -25,7 +25,7 @@
+     "@antfu/eslint-config": "^3.8.0",
+     "@types/jest": "^29.5.14",
+     "@types/js-yaml": "^4.0.9",
+-    "@types/node": "22.8.4",
++    "@types/node": "22.8.5",
+     "@typescript-eslint/eslint-plugin": "^8.12.2",
+     "@typescript-eslint/parser": "^8.12.2",
+     "aws-cdk": "2.164.1",
+@@ -40,7 +40,7 @@
+     "aws-cdk-lib": "2.164.1",
+     "constructs": "^10.4.2",
+     "js-yaml": "^4.1.0",
+-    "p6-cdk-website-plus": "^1.0.0",
++    "p6-cdk-website-plus": "^1.0.2",
+     "source-map-support": "^0.5.21"
+   },
+   "keywords": [
+diff --git a/pnpm-lock.yaml b/pnpm-lock.yaml
+index 010348b..531a872 100644
+--- a/pnpm-lock.yaml
++++ b/pnpm-lock.yaml
+@@ -18,8 +18,8 @@ importers:
+         specifier: ^4.1.0
+         version: 4.1.0
+       p6-cdk-website-plus:
+-        specifier: ^1.0.0
+-        version: 1.0.0(aws-cdk-lib@2.164.1(constructs@10.4.2))(constructs@10.4.2)
++        specifier: ^1.0.2
++        version: 1.0.2(aws-cdk-lib@2.164.1(constructs@10.4.2))(constructs@10.4.2)
+       source-map-support:
+         specifier: ^0.5.21
+         version: 0.5.21
+@@ -34,8 +34,8 @@ importers:
+         specifier: ^4.0.9
+         version: 4.0.9
+       '@types/node':
+-        specifier: 22.8.4
+-        version: 22.8.4
++        specifier: 22.8.5
++        version: 22.8.5
+       '@typescript-eslint/eslint-plugin':
+         specifier: ^8.12.2
+         version: 8.12.2(@typescript-eslint/parser@8.12.2(eslint@9.13.0)(typescript@5.6.3))(eslint@9.13.0)(typescript@5.6.3)
+@@ -53,13 +53,13 @@ importers:
+         version: 2.31.0(@typescript-eslint/parser@8.12.2(eslint@9.13.0)(typescript@5.6.3))(eslint@9.13.0)
+       jest:
+         specifier: ^29.7.0
+-        version: 29.7.0(@types/node@22.8.4)(ts-node@10.9.2(@types/node@22.8.4)(typescript@5.6.3))
++        version: 29.7.0(@types/node@22.8.5)(ts-node@10.9.2(@types/node@22.8.5)(typescript@5.6.3))
+       ts-jest:
+         specifier: ^29.2.5
+-        version: 29.2.5(@babel/core@7.26.0)(@jest/transform@29.7.0)(@jest/types@29.6.3)(babel-jest@29.7.0(@babel/core@7.26.0))(jest@29.7.0(@types/node@22.8.4)(ts-node@10.9.2(@types/node@22.8.4)(typescript@5.6.3)))(typescript@5.6.3)
++        version: 29.2.5(@babel/core@7.26.0)(@jest/transform@29.7.0)(@jest/types@29.6.3)(babel-jest@29.7.0(@babel/core@7.26.0))(jest@29.7.0(@types/node@22.8.5)(ts-node@10.9.2(@types/node@22.8.5)(typescript@5.6.3)))(typescript@5.6.3)
+       ts-node:
+         specifier: ^10.9.2
+-        version: 10.9.2(@types/node@22.8.4)(typescript@5.6.3)
++        version: 10.9.2(@types/node@22.8.5)(typescript@5.6.3)
+       typescript:
+         specifier: ~5.6.3
+         version: 5.6.3
+@@ -510,8 +510,8 @@ packages:
+   '@sinonjs/fake-timers@10.3.0':
+     resolution: {integrity: sha512-V4BG07kuYSUkTCSBHG8G8TNhM+F19jXFWnQtzj+we8DrkpSBCee9Z3Ms8yiGer/dlmhe35/Xdgyo3/0rQKg7YA==}
+ 
+-  '@stylistic/eslint-plugin@2.9.0':
+-    resolution: {integrity: sha512-OrDyFAYjBT61122MIY1a3SfEgy3YCMgt2vL4eoPmvTwDBwyQhAXurxNQznlRD/jESNfYWfID8Ej+31LljvF7Xg==}
++  '@stylistic/eslint-plugin@2.10.0':
++    resolution: {integrity: sha512-neWEgjp0qKxutbrKac5g23V5LX2c2Clyiz3zFxxybY8VSMfr+MmvwM204zg8YFbe9n2zcTwkpppCL2luwYcMhg==}
+     engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
+     peerDependencies:
+       eslint: '>=8.40.0'
+@@ -576,8 +576,8 @@ packages:
+   '@types/ms@0.7.34':
+     resolution: {integrity: sha512-nG96G3Wp6acyAgJqGasjODb+acrI7KltPiRxzHPXnP3NgI28bpQDRv53olbqGXbfcgF5aiiHmO3xpwEpS5Ld9g==}
+ 
+-  '@types/node@22.8.4':
+-    resolution: {integrity: sha512-SpNNxkftTJOPk0oN+y2bIqurEXHTA2AOZ3EJDDKeJ5VzkvvORSvmQXGQarcOzWV1ac7DCaPBEdMDxBsM+d8jWw==}
++  '@types/node@22.8.5':
++    resolution: {integrity: sha512-5iYk6AMPtsMbkZqCO1UGF9W5L38twq11S2pYWkybGHH2ogPUvXWNlQqJBzuEZWKj/WRH+QTeiv6ySWqJtvIEgA==}
+ 
+   '@types/normalize-package-data@2.4.4':
+     resolution: {integrity: sha512-37i+OaWTh9qeK4LSHPsyRC7NahnGotNuZvjLSgcPzblpHB3rrCJxAOgI5gCdKm7coonsaX1Of0ILiTcnZjbfxA==}
+@@ -859,8 +859,8 @@ packages:
+     resolution: {integrity: sha512-Gmy6FhYlCY7uOElZUSbxo2UCDH8owEk996gkbrpsgGtrJLM3J7jGxl9Ic7Qwwj4ivOE5AWZWRMecDdF7hqGjFA==}
+     engines: {node: '>=10'}
+ 
+-  caniuse-lite@1.0.30001675:
+-    resolution: {integrity: sha512-/wV1bQwPrkLiQMjaJF5yUMVM/VdRPOCU8QZ+PmG6uW6DvYSrNY1bpwHI/3mOcUosLaJCzYDi5o91IQB51ft6cg==}
++  caniuse-lite@1.0.30001676:
++    resolution: {integrity: sha512-Qz6zwGCiPghQXGJvgQAem79esjitvJ+CxSbSQkW9H/UX5hg8XM88d4lp2W+MEQ81j+Hip58Il+jGVdazk1z9cw==}
+ 
+   ccount@2.0.1:
+     resolution: {integrity: sha512-eyrF0jiFpY+3drT6383f1qhkbGsLSifNAjA61IUjZjmLCWjItY6LB9ft9YhoDgwfmclB2zhu51Lc7+95b8NRAg==}
+@@ -925,8 +925,8 @@ packages:
+   convert-source-map@2.0.0:
+     resolution: {integrity: sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg==}
+ 
+-  core-js-compat@3.38.1:
+-    resolution: {integrity: sha512-JRH6gfXxGmrzF3tZ57lFx97YARxCXPaMzPo6jELZhv88pBH5VXpQ+y0znKGlFnzuaihqhLbefxSJxWJMPtfDzw==}
++  core-js-compat@3.39.0:
++    resolution: {integrity: sha512-VgEUx3VwlExr5no0tXlBt+silBvhTryPwCXRI2Id1PN8WTKu7MreethvddqOubrYxkFdv/RnYrqlv1sFNAUelw==}
+ 
+   create-jest@29.7.0:
+     resolution: {integrity: sha512-Adz2bdH0Vq3F53KEMJOoftQFutWCukm6J24wbPWRO4k1kMY7gS7ds/uoJkNuV8wDCtWWnuwGcJwpWcih+zEW1Q==}
+@@ -1252,8 +1252,8 @@ packages:
+     peerDependencies:
+       eslint: ^6.2.0 || ^7.0.0 || ^8.0.0 || ^9.0.0
+ 
+-  eslint-plugin-yml@1.14.0:
+-    resolution: {integrity: sha512-ESUpgYPOcAYQO9czugcX5OqRvn/ydDVwGCPXY4YjPqc09rHaUVUA6IE6HLQys4rXk/S+qx3EwTd1wHCwam/OWQ==}
++  eslint-plugin-yml@1.15.0:
++    resolution: {integrity: sha512-leC8APYVOsKyWUlvRwVhewytK5wS70BfMqIaUplFstRfzCoVp0YoEroV4cUEvQrBj93tQ3M9LcjO/ewr6D4kjA==}
+     engines: {node: ^14.17.0 || >=16.0.0}
+     peerDependencies:
+       eslint: '>=6.0.0'
+@@ -2150,8 +2150,8 @@ packages:
+     resolution: {integrity: sha512-R4nPAVTAU0B9D35/Gk3uJf/7XYbQcyohSKdvAxIRSNghFl4e71hVoGnBNQz9cWaXxO2I10KTC+3jMdvvoKw6dQ==}
+     engines: {node: '>=6'}
+ 
+-  p6-cdk-website-plus@1.0.0:
+-    resolution: {integrity: sha512-UUHIQPUzEMrThQLTnTRhfQmIJhMFg21ihlc9QJ+zjqdr5OA1fH+VjwA2DzMgAzXL+hoZDOlWIVOZq2NYE2j9Ww==}
++  p6-cdk-website-plus@1.0.2:
++    resolution: {integrity: sha512-0rsDeSf2RRSchQpbvTZeM1u/0QuhtG08dX8+kgjBZlSJ2EqjDIdGNCgu63y5RRQhqHWfqO7Bz5gmwyVaegDO2A==}
+     peerDependencies:
+       aws-cdk-lib: 2.164.1
+       constructs: ^10.4.2
+@@ -2729,7 +2729,7 @@ snapshots:
+       '@clack/prompts': 0.7.0
+       '@eslint-community/eslint-plugin-eslint-comments': 4.4.1(eslint@9.13.0)
+       '@eslint/markdown': 6.2.1
+-      '@stylistic/eslint-plugin': 2.9.0(eslint@9.13.0)(typescript@5.6.3)
++      '@stylistic/eslint-plugin': 2.10.0(eslint@9.13.0)(typescript@5.6.3)
+       '@typescript-eslint/eslint-plugin': 8.12.2(@typescript-eslint/parser@8.12.2(eslint@9.13.0)(typescript@5.6.3))(eslint@9.13.0)(typescript@5.6.3)
+       '@typescript-eslint/parser': 8.12.2(eslint@9.13.0)(typescript@5.6.3)
+       '@vitest/eslint-plugin': 1.1.7(@typescript-eslint/utils@8.12.2(eslint@9.13.0)(typescript@5.6.3))(eslint@9.13.0)(typescript@5.6.3)
+@@ -2750,7 +2750,7 @@ snapshots:
+       eslint-plugin-unicorn: 56.0.0(eslint@9.13.0)
+       eslint-plugin-unused-imports: 4.1.4(@typescript-eslint/eslint-plugin@8.12.2(@typescript-eslint/parser@8.12.2(eslint@9.13.0)(typescript@5.6.3))(eslint@9.13.0)(typescript@5.6.3))(eslint@9.13.0)
+       eslint-plugin-vue: 9.30.0(eslint@9.13.0)
+-      eslint-plugin-yml: 1.14.0(eslint@9.13.0)
++      eslint-plugin-yml: 1.15.0(eslint@9.13.0)
+       eslint-processor-vue-blocks: 0.1.2(@vue/compiler-sfc@3.5.12)(eslint@9.13.0)
+       globals: 15.11.0
+       jsonc-eslint-parser: 2.4.0
+@@ -3080,27 +3080,27 @@ snapshots:
+   '@jest/console@29.7.0':
+     dependencies:
+       '@jest/types': 29.6.3
+-      '@types/node': 22.8.4
++      '@types/node': 22.8.5
+       chalk: 4.1.2
+       jest-message-util: 29.7.0
+       jest-util: 29.7.0
+       slash: 3.0.0
+ 
+-  '@jest/core@29.7.0(ts-node@10.9.2(@types/node@22.8.4)(typescript@5.6.3))':
++  '@jest/core@29.7.0(ts-node@10.9.2(@types/node@22.8.5)(typescript@5.6.3))':
+     dependencies:
+       '@jest/console': 29.7.0
+       '@jest/reporters': 29.7.0
+       '@jest/test-result': 29.7.0
+       '@jest/transform': 29.7.0
+       '@jest/types': 29.6.3
+-      '@types/node': 22.8.4
++      '@types/node': 22.8.5
+       ansi-escapes: 4.3.2
+       chalk: 4.1.2
+       ci-info: 3.9.0
+       exit: 0.1.2
+       graceful-fs: 4.2.11
+       jest-changed-files: 29.7.0
+-      jest-config: 29.7.0(@types/node@22.8.4)(ts-node@10.9.2(@types/node@22.8.4)(typescript@5.6.3))
++      jest-config: 29.7.0(@types/node@22.8.5)(ts-node@10.9.2(@types/node@22.8.5)(typescript@5.6.3))
+       jest-haste-map: 29.7.0
+       jest-message-util: 29.7.0
+       jest-regex-util: 29.6.3
+@@ -3125,7 +3125,7 @@ snapshots:
+     dependencies:
+       '@jest/fake-timers': 29.7.0
+       '@jest/types': 29.6.3
+-      '@types/node': 22.8.4
++      '@types/node': 22.8.5
+       jest-mock: 29.7.0
+ 
+   '@jest/expect-utils@29.7.0':
+@@ -3143,7 +3143,7 @@ snapshots:
+     dependencies:
+       '@jest/types': 29.6.3
+       '@sinonjs/fake-timers': 10.3.0
+-      '@types/node': 22.8.4
++      '@types/node': 22.8.5
+       jest-message-util: 29.7.0
+       jest-mock: 29.7.0
+       jest-util: 29.7.0
+@@ -3165,7 +3165,7 @@ snapshots:
+       '@jest/transform': 29.7.0
+       '@jest/types': 29.6.3
+       '@jridgewell/trace-mapping': 0.3.25
+-      '@types/node': 22.8.4
++      '@types/node': 22.8.5
+       chalk: 4.1.2
+       collect-v8-coverage: 1.0.2
+       exit: 0.1.2
+@@ -3235,7 +3235,7 @@ snapshots:
+       '@jest/schemas': 29.6.3
+       '@types/istanbul-lib-coverage': 2.0.6
+       '@types/istanbul-reports': 3.0.4
+-      '@types/node': 22.8.4
++      '@types/node': 22.8.5
+       '@types/yargs': 17.0.33
+       chalk: 4.1.2
+ 
+@@ -3287,7 +3287,7 @@ snapshots:
+     dependencies:
+       '@sinonjs/commons': 3.0.1
+ 
+-  '@stylistic/eslint-plugin@2.9.0(eslint@9.13.0)(typescript@5.6.3)':
++  '@stylistic/eslint-plugin@2.10.0(eslint@9.13.0)(typescript@5.6.3)':
+     dependencies:
+       '@typescript-eslint/utils': 8.12.2(eslint@9.13.0)(typescript@5.6.3)
+       eslint: 9.13.0
+@@ -3336,7 +3336,7 @@ snapshots:
+ 
+   '@types/graceful-fs@4.1.9':
+     dependencies:
+-      '@types/node': 22.8.4
++      '@types/node': 22.8.5
+ 
+   '@types/istanbul-lib-coverage@2.0.6': {}
+ 
+@@ -3365,7 +3365,7 @@ snapshots:
+ 
+   '@types/ms@0.7.34': {}
+ 
+-  '@types/node@22.8.4':
++  '@types/node@22.8.5':
+     dependencies:
+       undici-types: 6.19.8
+ 
+@@ -3685,7 +3685,7 @@ snapshots:
+ 
+   browserslist@4.24.2:
+     dependencies:
+-      caniuse-lite: 1.0.30001675
++      caniuse-lite: 1.0.30001676
+       electron-to-chromium: 1.5.49
+       node-releases: 2.0.18
+       update-browserslist-db: 1.1.1(browserslist@4.24.2)
+@@ -3716,7 +3716,7 @@ snapshots:
+ 
+   camelcase@6.3.0: {}
+ 
+-  caniuse-lite@1.0.30001675: {}
++  caniuse-lite@1.0.30001676: {}
+ 
+   ccount@2.0.1: {}
+ 
+@@ -3765,17 +3765,17 @@ snapshots:
+ 
+   convert-source-map@2.0.0: {}
+ 
+-  core-js-compat@3.38.1:
++  core-js-compat@3.39.0:
+     dependencies:
+       browserslist: 4.24.2
+ 
+-  create-jest@29.7.0(@types/node@22.8.4)(ts-node@10.9.2(@types/node@22.8.4)(typescript@5.6.3)):
++  create-jest@29.7.0(@types/node@22.8.5)(ts-node@10.9.2(@types/node@22.8.5)(typescript@5.6.3)):
+     dependencies:
+       '@jest/types': 29.6.3
+       chalk: 4.1.2
+       exit: 0.1.2
+       graceful-fs: 4.2.11
+-      jest-config: 29.7.0(@types/node@22.8.4)(ts-node@10.9.2(@types/node@22.8.4)(typescript@5.6.3))
++      jest-config: 29.7.0(@types/node@22.8.5)(ts-node@10.9.2(@types/node@22.8.5)(typescript@5.6.3))
+       jest-util: 29.7.0
+       prompts: 2.4.2
+     transitivePeerDependencies:
+@@ -4152,7 +4152,7 @@ snapshots:
+       '@eslint-community/eslint-utils': 4.4.1(eslint@9.13.0)
+       ci-info: 4.0.0
+       clean-regexp: 1.0.0
+-      core-js-compat: 3.38.1
++      core-js-compat: 3.39.0
+       eslint: 9.13.0
+       esquery: 1.6.0
+       globals: 15.11.0
+@@ -4186,7 +4186,7 @@ snapshots:
+     transitivePeerDependencies:
+       - supports-color
+ 
+-  eslint-plugin-yml@1.14.0(eslint@9.13.0):
++  eslint-plugin-yml@1.15.0(eslint@9.13.0):
+     dependencies:
+       debug: 4.3.7
+       eslint: 9.13.0
+@@ -4646,7 +4646,7 @@ snapshots:
+       '@jest/expect': 29.7.0
+       '@jest/test-result': 29.7.0
+       '@jest/types': 29.6.3
+-      '@types/node': 22.8.4
++      '@types/node': 22.8.5
+       chalk: 4.1.2
+       co: 4.6.0
+       dedent: 1.5.3
+@@ -4666,16 +4666,16 @@ snapshots:
+       - babel-plugin-macros
+       - supports-color
+ 
+-  jest-cli@29.7.0(@types/node@22.8.4)(ts-node@10.9.2(@types/node@22.8.4)(typescript@5.6.3)):
++  jest-cli@29.7.0(@types/node@22.8.5)(ts-node@10.9.2(@types/node@22.8.5)(typescript@5.6.3)):
+     dependencies:
+-      '@jest/core': 29.7.0(ts-node@10.9.2(@types/node@22.8.4)(typescript@5.6.3))
++      '@jest/core': 29.7.0(ts-node@10.9.2(@types/node@22.8.5)(typescript@5.6.3))
+       '@jest/test-result': 29.7.0
+       '@jest/types': 29.6.3
+       chalk: 4.1.2
+-      create-jest: 29.7.0(@types/node@22.8.4)(ts-node@10.9.2(@types/node@22.8.4)(typescript@5.6.3))
++      create-jest: 29.7.0(@types/node@22.8.5)(ts-node@10.9.2(@types/node@22.8.5)(typescript@5.6.3))
+       exit: 0.1.2
+       import-local: 3.2.0
+-      jest-config: 29.7.0(@types/node@22.8.4)(ts-node@10.9.2(@types/node@22.8.4)(typescript@5.6.3))
++      jest-config: 29.7.0(@types/node@22.8.5)(ts-node@10.9.2(@types/node@22.8.5)(typescript@5.6.3))
+       jest-util: 29.7.0
+       jest-validate: 29.7.0
+       yargs: 17.7.2
+@@ -4685,7 +4685,7 @@ snapshots:
+       - supports-color
+       - ts-node
+ 
+-  jest-config@29.7.0(@types/node@22.8.4)(ts-node@10.9.2(@types/node@22.8.4)(typescript@5.6.3)):
++  jest-config@29.7.0(@types/node@22.8.5)(ts-node@10.9.2(@types/node@22.8.5)(typescript@5.6.3)):
+     dependencies:
+       '@babel/core': 7.26.0
+       '@jest/test-sequencer': 29.7.0
+@@ -4710,8 +4710,8 @@ snapshots:
+       slash: 3.0.0
+       strip-json-comments: 3.1.1
+     optionalDependencies:
+-      '@types/node': 22.8.4
+-      ts-node: 10.9.2(@types/node@22.8.4)(typescript@5.6.3)
++      '@types/node': 22.8.5
++      ts-node: 10.9.2(@types/node@22.8.5)(typescript@5.6.3)
+     transitivePeerDependencies:
+       - babel-plugin-macros
+       - supports-color
+@@ -4740,7 +4740,7 @@ snapshots:
+       '@jest/environment': 29.7.0
+       '@jest/fake-timers': 29.7.0
+       '@jest/types': 29.6.3
+-      '@types/node': 22.8.4
++      '@types/node': 22.8.5
+       jest-mock: 29.7.0
+       jest-util: 29.7.0
+ 
+@@ -4750,7 +4750,7 @@ snapshots:
+     dependencies:
+       '@jest/types': 29.6.3
+       '@types/graceful-fs': 4.1.9
+-      '@types/node': 22.8.4
++      '@types/node': 22.8.5
+       anymatch: 3.1.3
+       fb-watchman: 2.0.2
+       graceful-fs: 4.2.11
+@@ -4789,7 +4789,7 @@ snapshots:
+   jest-mock@29.7.0:
+     dependencies:
+       '@jest/types': 29.6.3
+-      '@types/node': 22.8.4
++      '@types/node': 22.8.5
+       jest-util: 29.7.0
+ 
+   jest-pnp-resolver@1.2.3(jest-resolve@29.7.0):
+@@ -4824,7 +4824,7 @@ snapshots:
+       '@jest/test-result': 29.7.0
+       '@jest/transform': 29.7.0
+       '@jest/types': 29.6.3
+-      '@types/node': 22.8.4
++      '@types/node': 22.8.5
+       chalk: 4.1.2
+       emittery: 0.13.1
+       graceful-fs: 4.2.11
+@@ -4852,7 +4852,7 @@ snapshots:
+       '@jest/test-result': 29.7.0
+       '@jest/transform': 29.7.0
+       '@jest/types': 29.6.3
+-      '@types/node': 22.8.4
++      '@types/node': 22.8.5
+       chalk: 4.1.2
+       cjs-module-lexer: 1.4.1
+       collect-v8-coverage: 1.0.2
+@@ -4898,7 +4898,7 @@ snapshots:
+   jest-util@29.7.0:
+     dependencies:
+       '@jest/types': 29.6.3
+-      '@types/node': 22.8.4
++      '@types/node': 22.8.5
+       chalk: 4.1.2
+       ci-info: 3.9.0
+       graceful-fs: 4.2.11
+@@ -4917,7 +4917,7 @@ snapshots:
+     dependencies:
+       '@jest/test-result': 29.7.0
+       '@jest/types': 29.6.3
+-      '@types/node': 22.8.4
++      '@types/node': 22.8.5
+       ansi-escapes: 4.3.2
+       chalk: 4.1.2
+       emittery: 0.13.1
+@@ -4926,17 +4926,17 @@ snapshots:
+ 
+   jest-worker@29.7.0:
+     dependencies:
+-      '@types/node': 22.8.4
++      '@types/node': 22.8.5
+       jest-util: 29.7.0
+       merge-stream: 2.0.0
+       supports-color: 8.1.1
+ 
+-  jest@29.7.0(@types/node@22.8.4)(ts-node@10.9.2(@types/node@22.8.4)(typescript@5.6.3)):
++  jest@29.7.0(@types/node@22.8.5)(ts-node@10.9.2(@types/node@22.8.5)(typescript@5.6.3)):
+     dependencies:
+-      '@jest/core': 29.7.0(ts-node@10.9.2(@types/node@22.8.4)(typescript@5.6.3))
++      '@jest/core': 29.7.0(ts-node@10.9.2(@types/node@22.8.5)(typescript@5.6.3))
+       '@jest/types': 29.6.3
+       import-local: 3.2.0
+-      jest-cli: 29.7.0(@types/node@22.8.4)(ts-node@10.9.2(@types/node@22.8.4)(typescript@5.6.3))
++      jest-cli: 29.7.0(@types/node@22.8.5)(ts-node@10.9.2(@types/node@22.8.5)(typescript@5.6.3))
+     transitivePeerDependencies:
+       - '@types/node'
+       - babel-plugin-macros
+@@ -5458,7 +5458,7 @@ snapshots:
+ 
+   p-try@2.2.0: {}
+ 
+-  p6-cdk-website-plus@1.0.0(aws-cdk-lib@2.164.1(constructs@10.4.2))(constructs@10.4.2):
++  p6-cdk-website-plus@1.0.2(aws-cdk-lib@2.164.1(constructs@10.4.2))(constructs@10.4.2):
+     dependencies:
+       aws-cdk-lib: 2.164.1(constructs@10.4.2)
+       constructs: 10.4.2
+@@ -5802,12 +5802,12 @@ snapshots:
+     dependencies:
+       typescript: 5.6.3
+ 
+-  ts-jest@29.2.5(@babel/core@7.26.0)(@jest/transform@29.7.0)(@jest/types@29.6.3)(babel-jest@29.7.0(@babel/core@7.26.0))(jest@29.7.0(@types/node@22.8.4)(ts-node@10.9.2(@types/node@22.8.4)(typescript@5.6.3)))(typescript@5.6.3):
++  ts-jest@29.2.5(@babel/core@7.26.0)(@jest/transform@29.7.0)(@jest/types@29.6.3)(babel-jest@29.7.0(@babel/core@7.26.0))(jest@29.7.0(@types/node@22.8.5)(ts-node@10.9.2(@types/node@22.8.5)(typescript@5.6.3)))(typescript@5.6.3):
+     dependencies:
+       bs-logger: 0.2.6
+       ejs: 3.1.10
+       fast-json-stable-stringify: 2.1.0
+-      jest: 29.7.0(@types/node@22.8.4)(ts-node@10.9.2(@types/node@22.8.4)(typescript@5.6.3))
++      jest: 29.7.0(@types/node@22.8.5)(ts-node@10.9.2(@types/node@22.8.5)(typescript@5.6.3))
+       jest-util: 29.7.0
+       json5: 2.2.3
+       lodash.memoize: 4.1.2
+@@ -5821,14 +5821,14 @@ snapshots:
+       '@jest/types': 29.6.3
+       babel-jest: 29.7.0(@babel/core@7.26.0)
+ 
+-  ts-node@10.9.2(@types/node@22.8.4)(typescript@5.6.3):
++  ts-node@10.9.2(@types/node@22.8.5)(typescript@5.6.3):
+     dependencies:
+       '@cspotcode/source-map-support': 0.8.1
+       '@tsconfig/node10': 1.0.11
+       '@tsconfig/node12': 1.0.11
+       '@tsconfig/node14': 1.0.3
+       '@tsconfig/node16': 1.0.4
+-      '@types/node': 22.8.4
++      '@types/node': 22.8.5
+       acorn: 8.14.0
+       acorn-walk: 8.3.4
+       arg: 4.1.3

--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
     "@antfu/eslint-config": "^3.8.0",
     "@types/jest": "^29.5.14",
     "@types/js-yaml": "^4.0.9",
-    "@types/node": "22.8.4",
+    "@types/node": "22.8.5",
     "@typescript-eslint/eslint-plugin": "^8.12.2",
     "@typescript-eslint/parser": "^8.12.2",
     "aws-cdk": "2.164.1",
@@ -40,7 +40,7 @@
     "aws-cdk-lib": "2.164.1",
     "constructs": "^10.4.2",
     "js-yaml": "^4.1.0",
-    "p6-cdk-website-plus": "^1.0.0",
+    "p6-cdk-website-plus": "^1.0.2",
     "source-map-support": "^0.5.21"
   },
   "keywords": [

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -18,8 +18,8 @@ importers:
         specifier: ^4.1.0
         version: 4.1.0
       p6-cdk-website-plus:
-        specifier: ^1.0.0
-        version: 1.0.0(aws-cdk-lib@2.164.1(constructs@10.4.2))(constructs@10.4.2)
+        specifier: ^1.0.2
+        version: 1.0.2(aws-cdk-lib@2.164.1(constructs@10.4.2))(constructs@10.4.2)
       source-map-support:
         specifier: ^0.5.21
         version: 0.5.21
@@ -34,8 +34,8 @@ importers:
         specifier: ^4.0.9
         version: 4.0.9
       '@types/node':
-        specifier: 22.8.4
-        version: 22.8.4
+        specifier: 22.8.5
+        version: 22.8.5
       '@typescript-eslint/eslint-plugin':
         specifier: ^8.12.2
         version: 8.12.2(@typescript-eslint/parser@8.12.2(eslint@9.13.0)(typescript@5.6.3))(eslint@9.13.0)(typescript@5.6.3)
@@ -53,13 +53,13 @@ importers:
         version: 2.31.0(@typescript-eslint/parser@8.12.2(eslint@9.13.0)(typescript@5.6.3))(eslint@9.13.0)
       jest:
         specifier: ^29.7.0
-        version: 29.7.0(@types/node@22.8.4)(ts-node@10.9.2(@types/node@22.8.4)(typescript@5.6.3))
+        version: 29.7.0(@types/node@22.8.5)(ts-node@10.9.2(@types/node@22.8.5)(typescript@5.6.3))
       ts-jest:
         specifier: ^29.2.5
-        version: 29.2.5(@babel/core@7.26.0)(@jest/transform@29.7.0)(@jest/types@29.6.3)(babel-jest@29.7.0(@babel/core@7.26.0))(jest@29.7.0(@types/node@22.8.4)(ts-node@10.9.2(@types/node@22.8.4)(typescript@5.6.3)))(typescript@5.6.3)
+        version: 29.2.5(@babel/core@7.26.0)(@jest/transform@29.7.0)(@jest/types@29.6.3)(babel-jest@29.7.0(@babel/core@7.26.0))(jest@29.7.0(@types/node@22.8.5)(ts-node@10.9.2(@types/node@22.8.5)(typescript@5.6.3)))(typescript@5.6.3)
       ts-node:
         specifier: ^10.9.2
-        version: 10.9.2(@types/node@22.8.4)(typescript@5.6.3)
+        version: 10.9.2(@types/node@22.8.5)(typescript@5.6.3)
       typescript:
         specifier: ~5.6.3
         version: 5.6.3
@@ -510,8 +510,8 @@ packages:
   '@sinonjs/fake-timers@10.3.0':
     resolution: {integrity: sha512-V4BG07kuYSUkTCSBHG8G8TNhM+F19jXFWnQtzj+we8DrkpSBCee9Z3Ms8yiGer/dlmhe35/Xdgyo3/0rQKg7YA==}
 
-  '@stylistic/eslint-plugin@2.9.0':
-    resolution: {integrity: sha512-OrDyFAYjBT61122MIY1a3SfEgy3YCMgt2vL4eoPmvTwDBwyQhAXurxNQznlRD/jESNfYWfID8Ej+31LljvF7Xg==}
+  '@stylistic/eslint-plugin@2.10.0':
+    resolution: {integrity: sha512-neWEgjp0qKxutbrKac5g23V5LX2c2Clyiz3zFxxybY8VSMfr+MmvwM204zg8YFbe9n2zcTwkpppCL2luwYcMhg==}
     engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
     peerDependencies:
       eslint: '>=8.40.0'
@@ -576,8 +576,8 @@ packages:
   '@types/ms@0.7.34':
     resolution: {integrity: sha512-nG96G3Wp6acyAgJqGasjODb+acrI7KltPiRxzHPXnP3NgI28bpQDRv53olbqGXbfcgF5aiiHmO3xpwEpS5Ld9g==}
 
-  '@types/node@22.8.4':
-    resolution: {integrity: sha512-SpNNxkftTJOPk0oN+y2bIqurEXHTA2AOZ3EJDDKeJ5VzkvvORSvmQXGQarcOzWV1ac7DCaPBEdMDxBsM+d8jWw==}
+  '@types/node@22.8.5':
+    resolution: {integrity: sha512-5iYk6AMPtsMbkZqCO1UGF9W5L38twq11S2pYWkybGHH2ogPUvXWNlQqJBzuEZWKj/WRH+QTeiv6ySWqJtvIEgA==}
 
   '@types/normalize-package-data@2.4.4':
     resolution: {integrity: sha512-37i+OaWTh9qeK4LSHPsyRC7NahnGotNuZvjLSgcPzblpHB3rrCJxAOgI5gCdKm7coonsaX1Of0ILiTcnZjbfxA==}
@@ -859,8 +859,8 @@ packages:
     resolution: {integrity: sha512-Gmy6FhYlCY7uOElZUSbxo2UCDH8owEk996gkbrpsgGtrJLM3J7jGxl9Ic7Qwwj4ivOE5AWZWRMecDdF7hqGjFA==}
     engines: {node: '>=10'}
 
-  caniuse-lite@1.0.30001675:
-    resolution: {integrity: sha512-/wV1bQwPrkLiQMjaJF5yUMVM/VdRPOCU8QZ+PmG6uW6DvYSrNY1bpwHI/3mOcUosLaJCzYDi5o91IQB51ft6cg==}
+  caniuse-lite@1.0.30001676:
+    resolution: {integrity: sha512-Qz6zwGCiPghQXGJvgQAem79esjitvJ+CxSbSQkW9H/UX5hg8XM88d4lp2W+MEQ81j+Hip58Il+jGVdazk1z9cw==}
 
   ccount@2.0.1:
     resolution: {integrity: sha512-eyrF0jiFpY+3drT6383f1qhkbGsLSifNAjA61IUjZjmLCWjItY6LB9ft9YhoDgwfmclB2zhu51Lc7+95b8NRAg==}
@@ -925,8 +925,8 @@ packages:
   convert-source-map@2.0.0:
     resolution: {integrity: sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg==}
 
-  core-js-compat@3.38.1:
-    resolution: {integrity: sha512-JRH6gfXxGmrzF3tZ57lFx97YARxCXPaMzPo6jELZhv88pBH5VXpQ+y0znKGlFnzuaihqhLbefxSJxWJMPtfDzw==}
+  core-js-compat@3.39.0:
+    resolution: {integrity: sha512-VgEUx3VwlExr5no0tXlBt+silBvhTryPwCXRI2Id1PN8WTKu7MreethvddqOubrYxkFdv/RnYrqlv1sFNAUelw==}
 
   create-jest@29.7.0:
     resolution: {integrity: sha512-Adz2bdH0Vq3F53KEMJOoftQFutWCukm6J24wbPWRO4k1kMY7gS7ds/uoJkNuV8wDCtWWnuwGcJwpWcih+zEW1Q==}
@@ -1252,8 +1252,8 @@ packages:
     peerDependencies:
       eslint: ^6.2.0 || ^7.0.0 || ^8.0.0 || ^9.0.0
 
-  eslint-plugin-yml@1.14.0:
-    resolution: {integrity: sha512-ESUpgYPOcAYQO9czugcX5OqRvn/ydDVwGCPXY4YjPqc09rHaUVUA6IE6HLQys4rXk/S+qx3EwTd1wHCwam/OWQ==}
+  eslint-plugin-yml@1.15.0:
+    resolution: {integrity: sha512-leC8APYVOsKyWUlvRwVhewytK5wS70BfMqIaUplFstRfzCoVp0YoEroV4cUEvQrBj93tQ3M9LcjO/ewr6D4kjA==}
     engines: {node: ^14.17.0 || >=16.0.0}
     peerDependencies:
       eslint: '>=6.0.0'
@@ -2150,8 +2150,8 @@ packages:
     resolution: {integrity: sha512-R4nPAVTAU0B9D35/Gk3uJf/7XYbQcyohSKdvAxIRSNghFl4e71hVoGnBNQz9cWaXxO2I10KTC+3jMdvvoKw6dQ==}
     engines: {node: '>=6'}
 
-  p6-cdk-website-plus@1.0.0:
-    resolution: {integrity: sha512-UUHIQPUzEMrThQLTnTRhfQmIJhMFg21ihlc9QJ+zjqdr5OA1fH+VjwA2DzMgAzXL+hoZDOlWIVOZq2NYE2j9Ww==}
+  p6-cdk-website-plus@1.0.2:
+    resolution: {integrity: sha512-0rsDeSf2RRSchQpbvTZeM1u/0QuhtG08dX8+kgjBZlSJ2EqjDIdGNCgu63y5RRQhqHWfqO7Bz5gmwyVaegDO2A==}
     peerDependencies:
       aws-cdk-lib: 2.164.1
       constructs: ^10.4.2
@@ -2729,7 +2729,7 @@ snapshots:
       '@clack/prompts': 0.7.0
       '@eslint-community/eslint-plugin-eslint-comments': 4.4.1(eslint@9.13.0)
       '@eslint/markdown': 6.2.1
-      '@stylistic/eslint-plugin': 2.9.0(eslint@9.13.0)(typescript@5.6.3)
+      '@stylistic/eslint-plugin': 2.10.0(eslint@9.13.0)(typescript@5.6.3)
       '@typescript-eslint/eslint-plugin': 8.12.2(@typescript-eslint/parser@8.12.2(eslint@9.13.0)(typescript@5.6.3))(eslint@9.13.0)(typescript@5.6.3)
       '@typescript-eslint/parser': 8.12.2(eslint@9.13.0)(typescript@5.6.3)
       '@vitest/eslint-plugin': 1.1.7(@typescript-eslint/utils@8.12.2(eslint@9.13.0)(typescript@5.6.3))(eslint@9.13.0)(typescript@5.6.3)
@@ -2750,7 +2750,7 @@ snapshots:
       eslint-plugin-unicorn: 56.0.0(eslint@9.13.0)
       eslint-plugin-unused-imports: 4.1.4(@typescript-eslint/eslint-plugin@8.12.2(@typescript-eslint/parser@8.12.2(eslint@9.13.0)(typescript@5.6.3))(eslint@9.13.0)(typescript@5.6.3))(eslint@9.13.0)
       eslint-plugin-vue: 9.30.0(eslint@9.13.0)
-      eslint-plugin-yml: 1.14.0(eslint@9.13.0)
+      eslint-plugin-yml: 1.15.0(eslint@9.13.0)
       eslint-processor-vue-blocks: 0.1.2(@vue/compiler-sfc@3.5.12)(eslint@9.13.0)
       globals: 15.11.0
       jsonc-eslint-parser: 2.4.0
@@ -3080,27 +3080,27 @@ snapshots:
   '@jest/console@29.7.0':
     dependencies:
       '@jest/types': 29.6.3
-      '@types/node': 22.8.4
+      '@types/node': 22.8.5
       chalk: 4.1.2
       jest-message-util: 29.7.0
       jest-util: 29.7.0
       slash: 3.0.0
 
-  '@jest/core@29.7.0(ts-node@10.9.2(@types/node@22.8.4)(typescript@5.6.3))':
+  '@jest/core@29.7.0(ts-node@10.9.2(@types/node@22.8.5)(typescript@5.6.3))':
     dependencies:
       '@jest/console': 29.7.0
       '@jest/reporters': 29.7.0
       '@jest/test-result': 29.7.0
       '@jest/transform': 29.7.0
       '@jest/types': 29.6.3
-      '@types/node': 22.8.4
+      '@types/node': 22.8.5
       ansi-escapes: 4.3.2
       chalk: 4.1.2
       ci-info: 3.9.0
       exit: 0.1.2
       graceful-fs: 4.2.11
       jest-changed-files: 29.7.0
-      jest-config: 29.7.0(@types/node@22.8.4)(ts-node@10.9.2(@types/node@22.8.4)(typescript@5.6.3))
+      jest-config: 29.7.0(@types/node@22.8.5)(ts-node@10.9.2(@types/node@22.8.5)(typescript@5.6.3))
       jest-haste-map: 29.7.0
       jest-message-util: 29.7.0
       jest-regex-util: 29.6.3
@@ -3125,7 +3125,7 @@ snapshots:
     dependencies:
       '@jest/fake-timers': 29.7.0
       '@jest/types': 29.6.3
-      '@types/node': 22.8.4
+      '@types/node': 22.8.5
       jest-mock: 29.7.0
 
   '@jest/expect-utils@29.7.0':
@@ -3143,7 +3143,7 @@ snapshots:
     dependencies:
       '@jest/types': 29.6.3
       '@sinonjs/fake-timers': 10.3.0
-      '@types/node': 22.8.4
+      '@types/node': 22.8.5
       jest-message-util: 29.7.0
       jest-mock: 29.7.0
       jest-util: 29.7.0
@@ -3165,7 +3165,7 @@ snapshots:
       '@jest/transform': 29.7.0
       '@jest/types': 29.6.3
       '@jridgewell/trace-mapping': 0.3.25
-      '@types/node': 22.8.4
+      '@types/node': 22.8.5
       chalk: 4.1.2
       collect-v8-coverage: 1.0.2
       exit: 0.1.2
@@ -3235,7 +3235,7 @@ snapshots:
       '@jest/schemas': 29.6.3
       '@types/istanbul-lib-coverage': 2.0.6
       '@types/istanbul-reports': 3.0.4
-      '@types/node': 22.8.4
+      '@types/node': 22.8.5
       '@types/yargs': 17.0.33
       chalk: 4.1.2
 
@@ -3287,7 +3287,7 @@ snapshots:
     dependencies:
       '@sinonjs/commons': 3.0.1
 
-  '@stylistic/eslint-plugin@2.9.0(eslint@9.13.0)(typescript@5.6.3)':
+  '@stylistic/eslint-plugin@2.10.0(eslint@9.13.0)(typescript@5.6.3)':
     dependencies:
       '@typescript-eslint/utils': 8.12.2(eslint@9.13.0)(typescript@5.6.3)
       eslint: 9.13.0
@@ -3336,7 +3336,7 @@ snapshots:
 
   '@types/graceful-fs@4.1.9':
     dependencies:
-      '@types/node': 22.8.4
+      '@types/node': 22.8.5
 
   '@types/istanbul-lib-coverage@2.0.6': {}
 
@@ -3365,7 +3365,7 @@ snapshots:
 
   '@types/ms@0.7.34': {}
 
-  '@types/node@22.8.4':
+  '@types/node@22.8.5':
     dependencies:
       undici-types: 6.19.8
 
@@ -3685,7 +3685,7 @@ snapshots:
 
   browserslist@4.24.2:
     dependencies:
-      caniuse-lite: 1.0.30001675
+      caniuse-lite: 1.0.30001676
       electron-to-chromium: 1.5.49
       node-releases: 2.0.18
       update-browserslist-db: 1.1.1(browserslist@4.24.2)
@@ -3716,7 +3716,7 @@ snapshots:
 
   camelcase@6.3.0: {}
 
-  caniuse-lite@1.0.30001675: {}
+  caniuse-lite@1.0.30001676: {}
 
   ccount@2.0.1: {}
 
@@ -3765,17 +3765,17 @@ snapshots:
 
   convert-source-map@2.0.0: {}
 
-  core-js-compat@3.38.1:
+  core-js-compat@3.39.0:
     dependencies:
       browserslist: 4.24.2
 
-  create-jest@29.7.0(@types/node@22.8.4)(ts-node@10.9.2(@types/node@22.8.4)(typescript@5.6.3)):
+  create-jest@29.7.0(@types/node@22.8.5)(ts-node@10.9.2(@types/node@22.8.5)(typescript@5.6.3)):
     dependencies:
       '@jest/types': 29.6.3
       chalk: 4.1.2
       exit: 0.1.2
       graceful-fs: 4.2.11
-      jest-config: 29.7.0(@types/node@22.8.4)(ts-node@10.9.2(@types/node@22.8.4)(typescript@5.6.3))
+      jest-config: 29.7.0(@types/node@22.8.5)(ts-node@10.9.2(@types/node@22.8.5)(typescript@5.6.3))
       jest-util: 29.7.0
       prompts: 2.4.2
     transitivePeerDependencies:
@@ -4152,7 +4152,7 @@ snapshots:
       '@eslint-community/eslint-utils': 4.4.1(eslint@9.13.0)
       ci-info: 4.0.0
       clean-regexp: 1.0.0
-      core-js-compat: 3.38.1
+      core-js-compat: 3.39.0
       eslint: 9.13.0
       esquery: 1.6.0
       globals: 15.11.0
@@ -4186,7 +4186,7 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  eslint-plugin-yml@1.14.0(eslint@9.13.0):
+  eslint-plugin-yml@1.15.0(eslint@9.13.0):
     dependencies:
       debug: 4.3.7
       eslint: 9.13.0
@@ -4646,7 +4646,7 @@ snapshots:
       '@jest/expect': 29.7.0
       '@jest/test-result': 29.7.0
       '@jest/types': 29.6.3
-      '@types/node': 22.8.4
+      '@types/node': 22.8.5
       chalk: 4.1.2
       co: 4.6.0
       dedent: 1.5.3
@@ -4666,16 +4666,16 @@ snapshots:
       - babel-plugin-macros
       - supports-color
 
-  jest-cli@29.7.0(@types/node@22.8.4)(ts-node@10.9.2(@types/node@22.8.4)(typescript@5.6.3)):
+  jest-cli@29.7.0(@types/node@22.8.5)(ts-node@10.9.2(@types/node@22.8.5)(typescript@5.6.3)):
     dependencies:
-      '@jest/core': 29.7.0(ts-node@10.9.2(@types/node@22.8.4)(typescript@5.6.3))
+      '@jest/core': 29.7.0(ts-node@10.9.2(@types/node@22.8.5)(typescript@5.6.3))
       '@jest/test-result': 29.7.0
       '@jest/types': 29.6.3
       chalk: 4.1.2
-      create-jest: 29.7.0(@types/node@22.8.4)(ts-node@10.9.2(@types/node@22.8.4)(typescript@5.6.3))
+      create-jest: 29.7.0(@types/node@22.8.5)(ts-node@10.9.2(@types/node@22.8.5)(typescript@5.6.3))
       exit: 0.1.2
       import-local: 3.2.0
-      jest-config: 29.7.0(@types/node@22.8.4)(ts-node@10.9.2(@types/node@22.8.4)(typescript@5.6.3))
+      jest-config: 29.7.0(@types/node@22.8.5)(ts-node@10.9.2(@types/node@22.8.5)(typescript@5.6.3))
       jest-util: 29.7.0
       jest-validate: 29.7.0
       yargs: 17.7.2
@@ -4685,7 +4685,7 @@ snapshots:
       - supports-color
       - ts-node
 
-  jest-config@29.7.0(@types/node@22.8.4)(ts-node@10.9.2(@types/node@22.8.4)(typescript@5.6.3)):
+  jest-config@29.7.0(@types/node@22.8.5)(ts-node@10.9.2(@types/node@22.8.5)(typescript@5.6.3)):
     dependencies:
       '@babel/core': 7.26.0
       '@jest/test-sequencer': 29.7.0
@@ -4710,8 +4710,8 @@ snapshots:
       slash: 3.0.0
       strip-json-comments: 3.1.1
     optionalDependencies:
-      '@types/node': 22.8.4
-      ts-node: 10.9.2(@types/node@22.8.4)(typescript@5.6.3)
+      '@types/node': 22.8.5
+      ts-node: 10.9.2(@types/node@22.8.5)(typescript@5.6.3)
     transitivePeerDependencies:
       - babel-plugin-macros
       - supports-color
@@ -4740,7 +4740,7 @@ snapshots:
       '@jest/environment': 29.7.0
       '@jest/fake-timers': 29.7.0
       '@jest/types': 29.6.3
-      '@types/node': 22.8.4
+      '@types/node': 22.8.5
       jest-mock: 29.7.0
       jest-util: 29.7.0
 
@@ -4750,7 +4750,7 @@ snapshots:
     dependencies:
       '@jest/types': 29.6.3
       '@types/graceful-fs': 4.1.9
-      '@types/node': 22.8.4
+      '@types/node': 22.8.5
       anymatch: 3.1.3
       fb-watchman: 2.0.2
       graceful-fs: 4.2.11
@@ -4789,7 +4789,7 @@ snapshots:
   jest-mock@29.7.0:
     dependencies:
       '@jest/types': 29.6.3
-      '@types/node': 22.8.4
+      '@types/node': 22.8.5
       jest-util: 29.7.0
 
   jest-pnp-resolver@1.2.3(jest-resolve@29.7.0):
@@ -4824,7 +4824,7 @@ snapshots:
       '@jest/test-result': 29.7.0
       '@jest/transform': 29.7.0
       '@jest/types': 29.6.3
-      '@types/node': 22.8.4
+      '@types/node': 22.8.5
       chalk: 4.1.2
       emittery: 0.13.1
       graceful-fs: 4.2.11
@@ -4852,7 +4852,7 @@ snapshots:
       '@jest/test-result': 29.7.0
       '@jest/transform': 29.7.0
       '@jest/types': 29.6.3
-      '@types/node': 22.8.4
+      '@types/node': 22.8.5
       chalk: 4.1.2
       cjs-module-lexer: 1.4.1
       collect-v8-coverage: 1.0.2
@@ -4898,7 +4898,7 @@ snapshots:
   jest-util@29.7.0:
     dependencies:
       '@jest/types': 29.6.3
-      '@types/node': 22.8.4
+      '@types/node': 22.8.5
       chalk: 4.1.2
       ci-info: 3.9.0
       graceful-fs: 4.2.11
@@ -4917,7 +4917,7 @@ snapshots:
     dependencies:
       '@jest/test-result': 29.7.0
       '@jest/types': 29.6.3
-      '@types/node': 22.8.4
+      '@types/node': 22.8.5
       ansi-escapes: 4.3.2
       chalk: 4.1.2
       emittery: 0.13.1
@@ -4926,17 +4926,17 @@ snapshots:
 
   jest-worker@29.7.0:
     dependencies:
-      '@types/node': 22.8.4
+      '@types/node': 22.8.5
       jest-util: 29.7.0
       merge-stream: 2.0.0
       supports-color: 8.1.1
 
-  jest@29.7.0(@types/node@22.8.4)(ts-node@10.9.2(@types/node@22.8.4)(typescript@5.6.3)):
+  jest@29.7.0(@types/node@22.8.5)(ts-node@10.9.2(@types/node@22.8.5)(typescript@5.6.3)):
     dependencies:
-      '@jest/core': 29.7.0(ts-node@10.9.2(@types/node@22.8.4)(typescript@5.6.3))
+      '@jest/core': 29.7.0(ts-node@10.9.2(@types/node@22.8.5)(typescript@5.6.3))
       '@jest/types': 29.6.3
       import-local: 3.2.0
-      jest-cli: 29.7.0(@types/node@22.8.4)(ts-node@10.9.2(@types/node@22.8.4)(typescript@5.6.3))
+      jest-cli: 29.7.0(@types/node@22.8.5)(ts-node@10.9.2(@types/node@22.8.5)(typescript@5.6.3))
     transitivePeerDependencies:
       - '@types/node'
       - babel-plugin-macros
@@ -5458,7 +5458,7 @@ snapshots:
 
   p-try@2.2.0: {}
 
-  p6-cdk-website-plus@1.0.0(aws-cdk-lib@2.164.1(constructs@10.4.2))(constructs@10.4.2):
+  p6-cdk-website-plus@1.0.2(aws-cdk-lib@2.164.1(constructs@10.4.2))(constructs@10.4.2):
     dependencies:
       aws-cdk-lib: 2.164.1(constructs@10.4.2)
       constructs: 10.4.2
@@ -5802,12 +5802,12 @@ snapshots:
     dependencies:
       typescript: 5.6.3
 
-  ts-jest@29.2.5(@babel/core@7.26.0)(@jest/transform@29.7.0)(@jest/types@29.6.3)(babel-jest@29.7.0(@babel/core@7.26.0))(jest@29.7.0(@types/node@22.8.4)(ts-node@10.9.2(@types/node@22.8.4)(typescript@5.6.3)))(typescript@5.6.3):
+  ts-jest@29.2.5(@babel/core@7.26.0)(@jest/transform@29.7.0)(@jest/types@29.6.3)(babel-jest@29.7.0(@babel/core@7.26.0))(jest@29.7.0(@types/node@22.8.5)(ts-node@10.9.2(@types/node@22.8.5)(typescript@5.6.3)))(typescript@5.6.3):
     dependencies:
       bs-logger: 0.2.6
       ejs: 3.1.10
       fast-json-stable-stringify: 2.1.0
-      jest: 29.7.0(@types/node@22.8.4)(ts-node@10.9.2(@types/node@22.8.4)(typescript@5.6.3))
+      jest: 29.7.0(@types/node@22.8.5)(ts-node@10.9.2(@types/node@22.8.5)(typescript@5.6.3))
       jest-util: 29.7.0
       json5: 2.2.3
       lodash.memoize: 4.1.2
@@ -5821,14 +5821,14 @@ snapshots:
       '@jest/types': 29.6.3
       babel-jest: 29.7.0(@babel/core@7.26.0)
 
-  ts-node@10.9.2(@types/node@22.8.4)(typescript@5.6.3):
+  ts-node@10.9.2(@types/node@22.8.5)(typescript@5.6.3):
     dependencies:
       '@cspotcode/source-map-support': 0.8.1
       '@tsconfig/node10': 1.0.11
       '@tsconfig/node12': 1.0.11
       '@tsconfig/node14': 1.0.3
       '@tsconfig/node16': 1.0.4
-      '@types/node': 22.8.4
+      '@types/node': 22.8.5
       acorn: 8.14.0
       acorn-walk: 8.3.4
       arg: 4.1.3


### PR DESCRIPTION
Upgrades project dependencies. The following changes were made:
```diff
diff --git a/package.json b/package.json
index 684a751..41a199e 100644
--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
     "@antfu/eslint-config": "^3.8.0",
     "@types/jest": "^29.5.14",
     "@types/js-yaml": "^4.0.9",
-    "@types/node": "22.8.4",
+    "@types/node": "22.8.5",
     "@typescript-eslint/eslint-plugin": "^8.12.2",
     "@typescript-eslint/parser": "^8.12.2",
     "aws-cdk": "2.164.1",
@@ -40,7 +40,7 @@
     "aws-cdk-lib": "2.164.1",
     "constructs": "^10.4.2",
     "js-yaml": "^4.1.0",
-    "p6-cdk-website-plus": "^1.0.0",
+    "p6-cdk-website-plus": "^1.0.2",
     "source-map-support": "^0.5.21"
   },
   "keywords": [
diff --git a/pnpm-lock.yaml b/pnpm-lock.yaml
index 010348b..531a872 100644
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -18,8 +18,8 @@ importers:
         specifier: ^4.1.0
         version: 4.1.0
       p6-cdk-website-plus:
-        specifier: ^1.0.0
-        version: 1.0.0(aws-cdk-lib@2.164.1(constructs@10.4.2))(constructs@10.4.2)
+        specifier: ^1.0.2
+        version: 1.0.2(aws-cdk-lib@2.164.1(constructs@10.4.2))(constructs@10.4.2)
       source-map-support:
         specifier: ^0.5.21
         version: 0.5.21
@@ -34,8 +34,8 @@ importers:
         specifier: ^4.0.9
         version: 4.0.9
       '@types/node':
-        specifier: 22.8.4
-        version: 22.8.4
+        specifier: 22.8.5
+        version: 22.8.5
       '@typescript-eslint/eslint-plugin':
         specifier: ^8.12.2
         version: 8.12.2(@typescript-eslint/parser@8.12.2(eslint@9.13.0)(typescript@5.6.3))(eslint@9.13.0)(typescript@5.6.3)
@@ -53,13 +53,13 @@ importers:
         version: 2.31.0(@typescript-eslint/parser@8.12.2(eslint@9.13.0)(typescript@5.6.3))(eslint@9.13.0)
       jest:
         specifier: ^29.7.0
-        version: 29.7.0(@types/node@22.8.4)(ts-node@10.9.2(@types/node@22.8.4)(typescript@5.6.3))
+        version: 29.7.0(@types/node@22.8.5)(ts-node@10.9.2(@types/node@22.8.5)(typescript@5.6.3))
       ts-jest:
         specifier: ^29.2.5
-        version: 29.2.5(@babel/core@7.26.0)(@jest/transform@29.7.0)(@jest/types@29.6.3)(babel-jest@29.7.0(@babel/core@7.26.0))(jest@29.7.0(@types/node@22.8.4)(ts-node@10.9.2(@types/node@22.8.4)(typescript@5.6.3)))(typescript@5.6.3)
+        version: 29.2.5(@babel/core@7.26.0)(@jest/transform@29.7.0)(@jest/types@29.6.3)(babel-jest@29.7.0(@babel/core@7.26.0))(jest@29.7.0(@types/node@22.8.5)(ts-node@10.9.2(@types/node@22.8.5)(typescript@5.6.3)))(typescript@5.6.3)
       ts-node:
         specifier: ^10.9.2
-        version: 10.9.2(@types/node@22.8.4)(typescript@5.6.3)
+        version: 10.9.2(@types/node@22.8.5)(typescript@5.6.3)
       typescript:
         specifier: ~5.6.3
         version: 5.6.3
@@ -510,8 +510,8 @@ packages:
   '@sinonjs/fake-timers@10.3.0':
     resolution: {integrity: sha512-V4BG07kuYSUkTCSBHG8G8TNhM+F19jXFWnQtzj+we8DrkpSBCee9Z3Ms8yiGer/dlmhe35/Xdgyo3/0rQKg7YA==}
 
-  '@stylistic/eslint-plugin@2.9.0':
-    resolution: {integrity: sha512-OrDyFAYjBT61122MIY1a3SfEgy3YCMgt2vL4eoPmvTwDBwyQhAXurxNQznlRD/jESNfYWfID8Ej+31LljvF7Xg==}
+  '@stylistic/eslint-plugin@2.10.0':
+    resolution: {integrity: sha512-neWEgjp0qKxutbrKac5g23V5LX2c2Clyiz3zFxxybY8VSMfr+MmvwM204zg8YFbe9n2zcTwkpppCL2luwYcMhg==}
     engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
     peerDependencies:
       eslint: '>=8.40.0'
@@ -576,8 +576,8 @@ packages:
   '@types/ms@0.7.34':
     resolution: {integrity: sha512-nG96G3Wp6acyAgJqGasjODb+acrI7KltPiRxzHPXnP3NgI28bpQDRv53olbqGXbfcgF5aiiHmO3xpwEpS5Ld9g==}
 
-  '@types/node@22.8.4':
-    resolution: {integrity: sha512-SpNNxkftTJOPk0oN+y2bIqurEXHTA2AOZ3EJDDKeJ5VzkvvORSvmQXGQarcOzWV1ac7DCaPBEdMDxBsM+d8jWw==}
+  '@types/node@22.8.5':
+    resolution: {integrity: sha512-5iYk6AMPtsMbkZqCO1UGF9W5L38twq11S2pYWkybGHH2ogPUvXWNlQqJBzuEZWKj/WRH+QTeiv6ySWqJtvIEgA==}
 
   '@types/normalize-package-data@2.4.4':
     resolution: {integrity: sha512-37i+OaWTh9qeK4LSHPsyRC7NahnGotNuZvjLSgcPzblpHB3rrCJxAOgI5gCdKm7coonsaX1Of0ILiTcnZjbfxA==}
@@ -859,8 +859,8 @@ packages:
     resolution: {integrity: sha512-Gmy6FhYlCY7uOElZUSbxo2UCDH8owEk996gkbrpsgGtrJLM3J7jGxl9Ic7Qwwj4ivOE5AWZWRMecDdF7hqGjFA==}
     engines: {node: '>=10'}
 
-  caniuse-lite@1.0.30001675:
-    resolution: {integrity: sha512-/wV1bQwPrkLiQMjaJF5yUMVM/VdRPOCU8QZ+PmG6uW6DvYSrNY1bpwHI/3mOcUosLaJCzYDi5o91IQB51ft6cg==}
+  caniuse-lite@1.0.30001676:
+    resolution: {integrity: sha512-Qz6zwGCiPghQXGJvgQAem79esjitvJ+CxSbSQkW9H/UX5hg8XM88d4lp2W+MEQ81j+Hip58Il+jGVdazk1z9cw==}
 
   ccount@2.0.1:
     resolution: {integrity: sha512-eyrF0jiFpY+3drT6383f1qhkbGsLSifNAjA61IUjZjmLCWjItY6LB9ft9YhoDgwfmclB2zhu51Lc7+95b8NRAg==}
@@ -925,8 +925,8 @@ packages:
   convert-source-map@2.0.0:
     resolution: {integrity: sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg==}
 
-  core-js-compat@3.38.1:
-    resolution: {integrity: sha512-JRH6gfXxGmrzF3tZ57lFx97YARxCXPaMzPo6jELZhv88pBH5VXpQ+y0znKGlFnzuaihqhLbefxSJxWJMPtfDzw==}
+  core-js-compat@3.39.0:
+    resolution: {integrity: sha512-VgEUx3VwlExr5no0tXlBt+silBvhTryPwCXRI2Id1PN8WTKu7MreethvddqOubrYxkFdv/RnYrqlv1sFNAUelw==}
 
   create-jest@29.7.0:
     resolution: {integrity: sha512-Adz2bdH0Vq3F53KEMJOoftQFutWCukm6J24wbPWRO4k1kMY7gS7ds/uoJkNuV8wDCtWWnuwGcJwpWcih+zEW1Q==}
@@ -1252,8 +1252,8 @@ packages:
     peerDependencies:
       eslint: ^6.2.0 || ^7.0.0 || ^8.0.0 || ^9.0.0
 
-  eslint-plugin-yml@1.14.0:
-    resolution: {integrity: sha512-ESUpgYPOcAYQO9czugcX5OqRvn/ydDVwGCPXY4YjPqc09rHaUVUA6IE6HLQys4rXk/S+qx3EwTd1wHCwam/OWQ==}
+  eslint-plugin-yml@1.15.0:
+    resolution: {integrity: sha512-leC8APYVOsKyWUlvRwVhewytK5wS70BfMqIaUplFstRfzCoVp0YoEroV4cUEvQrBj93tQ3M9LcjO/ewr6D4kjA==}
     engines: {node: ^14.17.0 || >=16.0.0}
     peerDependencies:
       eslint: '>=6.0.0'
@@ -2150,8 +2150,8 @@ packages:
     resolution: {integrity: sha512-R4nPAVTAU0B9D35/Gk3uJf/7XYbQcyohSKdvAxIRSNghFl4e71hVoGnBNQz9cWaXxO2I10KTC+3jMdvvoKw6dQ==}
     engines: {node: '>=6'}
 
-  p6-cdk-website-plus@1.0.0:
-    resolution: {integrity: sha512-UUHIQPUzEMrThQLTnTRhfQmIJhMFg21ihlc9QJ+zjqdr5OA1fH+VjwA2DzMgAzXL+hoZDOlWIVOZq2NYE2j9Ww==}
+  p6-cdk-website-plus@1.0.2:
+    resolution: {integrity: sha512-0rsDeSf2RRSchQpbvTZeM1u/0QuhtG08dX8+kgjBZlSJ2EqjDIdGNCgu63y5RRQhqHWfqO7Bz5gmwyVaegDO2A==}
     peerDependencies:
       aws-cdk-lib: 2.164.1
       constructs: ^10.4.2
@@ -2729,7 +2729,7 @@ snapshots:
       '@clack/prompts': 0.7.0
       '@eslint-community/eslint-plugin-eslint-comments': 4.4.1(eslint@9.13.0)
       '@eslint/markdown': 6.2.1
-      '@stylistic/eslint-plugin': 2.9.0(eslint@9.13.0)(typescript@5.6.3)
+      '@stylistic/eslint-plugin': 2.10.0(eslint@9.13.0)(typescript@5.6.3)
       '@typescript-eslint/eslint-plugin': 8.12.2(@typescript-eslint/parser@8.12.2(eslint@9.13.0)(typescript@5.6.3))(eslint@9.13.0)(typescript@5.6.3)
       '@typescript-eslint/parser': 8.12.2(eslint@9.13.0)(typescript@5.6.3)
       '@vitest/eslint-plugin': 1.1.7(@typescript-eslint/utils@8.12.2(eslint@9.13.0)(typescript@5.6.3))(eslint@9.13.0)(typescript@5.6.3)
@@ -2750,7 +2750,7 @@ snapshots:
       eslint-plugin-unicorn: 56.0.0(eslint@9.13.0)
       eslint-plugin-unused-imports: 4.1.4(@typescript-eslint/eslint-plugin@8.12.2(@typescript-eslint/parser@8.12.2(eslint@9.13.0)(typescript@5.6.3))(eslint@9.13.0)(typescript@5.6.3))(eslint@9.13.0)
       eslint-plugin-vue: 9.30.0(eslint@9.13.0)
-      eslint-plugin-yml: 1.14.0(eslint@9.13.0)
+      eslint-plugin-yml: 1.15.0(eslint@9.13.0)
       eslint-processor-vue-blocks: 0.1.2(@vue/compiler-sfc@3.5.12)(eslint@9.13.0)
       globals: 15.11.0
       jsonc-eslint-parser: 2.4.0
@@ -3080,27 +3080,27 @@ snapshots:
   '@jest/console@29.7.0':
     dependencies:
       '@jest/types': 29.6.3
-      '@types/node': 22.8.4
+      '@types/node': 22.8.5
       chalk: 4.1.2
       jest-message-util: 29.7.0
       jest-util: 29.7.0
       slash: 3.0.0
 
-  '@jest/core@29.7.0(ts-node@10.9.2(@types/node@22.8.4)(typescript@5.6.3))':
+  '@jest/core@29.7.0(ts-node@10.9.2(@types/node@22.8.5)(typescript@5.6.3))':
     dependencies:
       '@jest/console': 29.7.0
       '@jest/reporters': 29.7.0
       '@jest/test-result': 29.7.0
       '@jest/transform': 29.7.0
       '@jest/types': 29.6.3
-      '@types/node': 22.8.4
+      '@types/node': 22.8.5
       ansi-escapes: 4.3.2
       chalk: 4.1.2
       ci-info: 3.9.0
       exit: 0.1.2
       graceful-fs: 4.2.11
       jest-changed-files: 29.7.0
-      jest-config: 29.7.0(@types/node@22.8.4)(ts-node@10.9.2(@types/node@22.8.4)(typescript@5.6.3))
+      jest-config: 29.7.0(@types/node@22.8.5)(ts-node@10.9.2(@types/node@22.8.5)(typescript@5.6.3))
       jest-haste-map: 29.7.0
       jest-message-util: 29.7.0
       jest-regex-util: 29.6.3
@@ -3125,7 +3125,7 @@ snapshots:
     dependencies:
       '@jest/fake-timers': 29.7.0
       '@jest/types': 29.6.3
-      '@types/node': 22.8.4
+      '@types/node': 22.8.5
       jest-mock: 29.7.0
 
   '@jest/expect-utils@29.7.0':
@@ -3143,7 +3143,7 @@ snapshots:
     dependencies:
       '@jest/types': 29.6.3
       '@sinonjs/fake-timers': 10.3.0
-      '@types/node': 22.8.4
+      '@types/node': 22.8.5
       jest-message-util: 29.7.0
       jest-mock: 29.7.0
       jest-util: 29.7.0
@@ -3165,7 +3165,7 @@ snapshots:
       '@jest/transform': 29.7.0
       '@jest/types': 29.6.3
       '@jridgewell/trace-mapping': 0.3.25
-      '@types/node': 22.8.4
+      '@types/node': 22.8.5
       chalk: 4.1.2
       collect-v8-coverage: 1.0.2
       exit: 0.1.2
@@ -3235,7 +3235,7 @@ snapshots:
       '@jest/schemas': 29.6.3
       '@types/istanbul-lib-coverage': 2.0.6
       '@types/istanbul-reports': 3.0.4
-      '@types/node': 22.8.4
+      '@types/node': 22.8.5
       '@types/yargs': 17.0.33
       chalk: 4.1.2
 
@@ -3287,7 +3287,7 @@ snapshots:
     dependencies:
       '@sinonjs/commons': 3.0.1
 
-  '@stylistic/eslint-plugin@2.9.0(eslint@9.13.0)(typescript@5.6.3)':
+  '@stylistic/eslint-plugin@2.10.0(eslint@9.13.0)(typescript@5.6.3)':
     dependencies:
       '@typescript-eslint/utils': 8.12.2(eslint@9.13.0)(typescript@5.6.3)
       eslint: 9.13.0
@@ -3336,7 +3336,7 @@ snapshots:
 
   '@types/graceful-fs@4.1.9':
     dependencies:
-      '@types/node': 22.8.4
+      '@types/node': 22.8.5
 
   '@types/istanbul-lib-coverage@2.0.6': {}
 
@@ -3365,7 +3365,7 @@ snapshots:
 
   '@types/ms@0.7.34': {}
 
-  '@types/node@22.8.4':
+  '@types/node@22.8.5':
     dependencies:
       undici-types: 6.19.8
 
@@ -3685,7 +3685,7 @@ snapshots:
 
   browserslist@4.24.2:
     dependencies:
-      caniuse-lite: 1.0.30001675
+      caniuse-lite: 1.0.30001676
       electron-to-chromium: 1.5.49
       node-releases: 2.0.18
       update-browserslist-db: 1.1.1(browserslist@4.24.2)
@@ -3716,7 +3716,7 @@ snapshots:
 
   camelcase@6.3.0: {}
 
-  caniuse-lite@1.0.30001675: {}
+  caniuse-lite@1.0.30001676: {}
 
   ccount@2.0.1: {}
 
@@ -3765,17 +3765,17 @@ snapshots:
 
   convert-source-map@2.0.0: {}
 
-  core-js-compat@3.38.1:
+  core-js-compat@3.39.0:
     dependencies:
       browserslist: 4.24.2
 
-  create-jest@29.7.0(@types/node@22.8.4)(ts-node@10.9.2(@types/node@22.8.4)(typescript@5.6.3)):
+  create-jest@29.7.0(@types/node@22.8.5)(ts-node@10.9.2(@types/node@22.8.5)(typescript@5.6.3)):
     dependencies:
       '@jest/types': 29.6.3
       chalk: 4.1.2
       exit: 0.1.2
       graceful-fs: 4.2.11
-      jest-config: 29.7.0(@types/node@22.8.4)(ts-node@10.9.2(@types/node@22.8.4)(typescript@5.6.3))
+      jest-config: 29.7.0(@types/node@22.8.5)(ts-node@10.9.2(@types/node@22.8.5)(typescript@5.6.3))
       jest-util: 29.7.0
       prompts: 2.4.2
     transitivePeerDependencies:
@@ -4152,7 +4152,7 @@ snapshots:
       '@eslint-community/eslint-utils': 4.4.1(eslint@9.13.0)
       ci-info: 4.0.0
       clean-regexp: 1.0.0
-      core-js-compat: 3.38.1
+      core-js-compat: 3.39.0
       eslint: 9.13.0
       esquery: 1.6.0
       globals: 15.11.0
@@ -4186,7 +4186,7 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  eslint-plugin-yml@1.14.0(eslint@9.13.0):
+  eslint-plugin-yml@1.15.0(eslint@9.13.0):
     dependencies:
       debug: 4.3.7
       eslint: 9.13.0
@@ -4646,7 +4646,7 @@ snapshots:
       '@jest/expect': 29.7.0
       '@jest/test-result': 29.7.0
       '@jest/types': 29.6.3
-      '@types/node': 22.8.4
+      '@types/node': 22.8.5
       chalk: 4.1.2
       co: 4.6.0
       dedent: 1.5.3
@@ -4666,16 +4666,16 @@ snapshots:
       - babel-plugin-macros
       - supports-color
 
-  jest-cli@29.7.0(@types/node@22.8.4)(ts-node@10.9.2(@types/node@22.8.4)(typescript@5.6.3)):
+  jest-cli@29.7.0(@types/node@22.8.5)(ts-node@10.9.2(@types/node@22.8.5)(typescript@5.6.3)):
     dependencies:
-      '@jest/core': 29.7.0(ts-node@10.9.2(@types/node@22.8.4)(typescript@5.6.3))
+      '@jest/core': 29.7.0(ts-node@10.9.2(@types/node@22.8.5)(typescript@5.6.3))
       '@jest/test-result': 29.7.0
       '@jest/types': 29.6.3
       chalk: 4.1.2
-      create-jest: 29.7.0(@types/node@22.8.4)(ts-node@10.9.2(@types/node@22.8.4)(typescript@5.6.3))
+      create-jest: 29.7.0(@types/node@22.8.5)(ts-node@10.9.2(@types/node@22.8.5)(typescript@5.6.3))
       exit: 0.1.2
       import-local: 3.2.0
-      jest-config: 29.7.0(@types/node@22.8.4)(ts-node@10.9.2(@types/node@22.8.4)(typescript@5.6.3))
+      jest-config: 29.7.0(@types/node@22.8.5)(ts-node@10.9.2(@types/node@22.8.5)(typescript@5.6.3))
       jest-util: 29.7.0
       jest-validate: 29.7.0
       yargs: 17.7.2
@@ -4685,7 +4685,7 @@ snapshots:
       - supports-color
       - ts-node
 
-  jest-config@29.7.0(@types/node@22.8.4)(ts-node@10.9.2(@types/node@22.8.4)(typescript@5.6.3)):
+  jest-config@29.7.0(@types/node@22.8.5)(ts-node@10.9.2(@types/node@22.8.5)(typescript@5.6.3)):
     dependencies:
       '@babel/core': 7.26.0
       '@jest/test-sequencer': 29.7.0
@@ -4710,8 +4710,8 @@ snapshots:
       slash: 3.0.0
       strip-json-comments: 3.1.1
     optionalDependencies:
-      '@types/node': 22.8.4
-      ts-node: 10.9.2(@types/node@22.8.4)(typescript@5.6.3)
+      '@types/node': 22.8.5
+      ts-node: 10.9.2(@types/node@22.8.5)(typescript@5.6.3)
     transitivePeerDependencies:
       - babel-plugin-macros
       - supports-color
@@ -4740,7 +4740,7 @@ snapshots:
       '@jest/environment': 29.7.0
       '@jest/fake-timers': 29.7.0
       '@jest/types': 29.6.3
-      '@types/node': 22.8.4
+      '@types/node': 22.8.5
       jest-mock: 29.7.0
       jest-util: 29.7.0
 
@@ -4750,7 +4750,7 @@ snapshots:
     dependencies:
       '@jest/types': 29.6.3
       '@types/graceful-fs': 4.1.9
-      '@types/node': 22.8.4
+      '@types/node': 22.8.5
       anymatch: 3.1.3
       fb-watchman: 2.0.2
       graceful-fs: 4.2.11
@@ -4789,7 +4789,7 @@ snapshots:
   jest-mock@29.7.0:
     dependencies:
       '@jest/types': 29.6.3
-      '@types/node': 22.8.4
+      '@types/node': 22.8.5
       jest-util: 29.7.0
 
   jest-pnp-resolver@1.2.3(jest-resolve@29.7.0):
@@ -4824,7 +4824,7 @@ snapshots:
       '@jest/test-result': 29.7.0
       '@jest/transform': 29.7.0
       '@jest/types': 29.6.3
-      '@types/node': 22.8.4
+      '@types/node': 22.8.5
       chalk: 4.1.2
       emittery: 0.13.1
       graceful-fs: 4.2.11
@@ -4852,7 +4852,7 @@ snapshots:
       '@jest/test-result': 29.7.0
       '@jest/transform': 29.7.0
       '@jest/types': 29.6.3
-      '@types/node': 22.8.4
+      '@types/node': 22.8.5
       chalk: 4.1.2
       cjs-module-lexer: 1.4.1
       collect-v8-coverage: 1.0.2
@@ -4898,7 +4898,7 @@ snapshots:
   jest-util@29.7.0:
     dependencies:
       '@jest/types': 29.6.3
-      '@types/node': 22.8.4
+      '@types/node': 22.8.5
       chalk: 4.1.2
       ci-info: 3.9.0
       graceful-fs: 4.2.11
@@ -4917,7 +4917,7 @@ snapshots:
     dependencies:
       '@jest/test-result': 29.7.0
       '@jest/types': 29.6.3
-      '@types/node': 22.8.4
+      '@types/node': 22.8.5
       ansi-escapes: 4.3.2
       chalk: 4.1.2
       emittery: 0.13.1
@@ -4926,17 +4926,17 @@ snapshots:
 
   jest-worker@29.7.0:
     dependencies:
-      '@types/node': 22.8.4
+      '@types/node': 22.8.5
       jest-util: 29.7.0
       merge-stream: 2.0.0
       supports-color: 8.1.1
 
-  jest@29.7.0(@types/node@22.8.4)(ts-node@10.9.2(@types/node@22.8.4)(typescript@5.6.3)):
+  jest@29.7.0(@types/node@22.8.5)(ts-node@10.9.2(@types/node@22.8.5)(typescript@5.6.3)):
     dependencies:
-      '@jest/core': 29.7.0(ts-node@10.9.2(@types/node@22.8.4)(typescript@5.6.3))
+      '@jest/core': 29.7.0(ts-node@10.9.2(@types/node@22.8.5)(typescript@5.6.3))
       '@jest/types': 29.6.3
       import-local: 3.2.0
-      jest-cli: 29.7.0(@types/node@22.8.4)(ts-node@10.9.2(@types/node@22.8.4)(typescript@5.6.3))
+      jest-cli: 29.7.0(@types/node@22.8.5)(ts-node@10.9.2(@types/node@22.8.5)(typescript@5.6.3))
     transitivePeerDependencies:
       - '@types/node'
       - babel-plugin-macros
@@ -5458,7 +5458,7 @@ snapshots:
 
   p-try@2.2.0: {}
 
-  p6-cdk-website-plus@1.0.0(aws-cdk-lib@2.164.1(constructs@10.4.2))(constructs@10.4.2):
+  p6-cdk-website-plus@1.0.2(aws-cdk-lib@2.164.1(constructs@10.4.2))(constructs@10.4.2):
     dependencies:
       aws-cdk-lib: 2.164.1(constructs@10.4.2)
       constructs: 10.4.2
@@ -5802,12 +5802,12 @@ snapshots:
     dependencies:
       typescript: 5.6.3
 
-  ts-jest@29.2.5(@babel/core@7.26.0)(@jest/transform@29.7.0)(@jest/types@29.6.3)(babel-jest@29.7.0(@babel/core@7.26.0))(jest@29.7.0(@types/node@22.8.4)(ts-node@10.9.2(@types/node@22.8.4)(typescript@5.6.3)))(typescript@5.6.3):
+  ts-jest@29.2.5(@babel/core@7.26.0)(@jest/transform@29.7.0)(@jest/types@29.6.3)(babel-jest@29.7.0(@babel/core@7.26.0))(jest@29.7.0(@types/node@22.8.5)(ts-node@10.9.2(@types/node@22.8.5)(typescript@5.6.3)))(typescript@5.6.3):
     dependencies:
       bs-logger: 0.2.6
       ejs: 3.1.10
       fast-json-stable-stringify: 2.1.0
-      jest: 29.7.0(@types/node@22.8.4)(ts-node@10.9.2(@types/node@22.8.4)(typescript@5.6.3))
+      jest: 29.7.0(@types/node@22.8.5)(ts-node@10.9.2(@types/node@22.8.5)(typescript@5.6.3))
       jest-util: 29.7.0
       json5: 2.2.3
       lodash.memoize: 4.1.2
@@ -5821,14 +5821,14 @@ snapshots:
       '@jest/types': 29.6.3
       babel-jest: 29.7.0(@babel/core@7.26.0)
 
-  ts-node@10.9.2(@types/node@22.8.4)(typescript@5.6.3):
+  ts-node@10.9.2(@types/node@22.8.5)(typescript@5.6.3):
     dependencies:
       '@cspotcode/source-map-support': 0.8.1
       '@tsconfig/node10': 1.0.11
       '@tsconfig/node12': 1.0.11
       '@tsconfig/node14': 1.0.3
       '@tsconfig/node16': 1.0.4
-      '@types/node': 22.8.4
+      '@types/node': 22.8.5
       acorn: 8.14.0
       acorn-walk: 8.3.4
       arg: 4.1.3
```