### PR TITLE
chore(deps): upgrade dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
     "@types/node": "22.10.5",
     "@typescript-eslint/eslint-plugin": "^8.19.0",
     "@typescript-eslint/parser": "^8.19.0",
-    "aws-cdk": "2.173.4",
+    "aws-cdk": "2.174.0",
     "eslint": "^9.17.0",
     "eslint-plugin-import": "^2.31.0",
     "jest": "^29.7.0",
@@ -40,7 +40,7 @@
     "node": ">= 22.10.0"
   },
   "dependencies": {
-    "aws-cdk-lib": "2.173.4",
+    "aws-cdk-lib": "2.174.0",
     "constructs": "^10.4.2",
     "js-yaml": "^4.1.0",
     "p6-cdk-gha-role": "^0.1.2",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -9,8 +9,8 @@ importers:
   .:
     dependencies:
       aws-cdk-lib:
-        specifier: 2.173.4
-        version: 2.173.4(constructs@10.4.2)
+        specifier: 2.174.0
+        version: 2.174.0(constructs@10.4.2)
       constructs:
         specifier: ^10.4.2
         version: 10.4.2
@@ -19,10 +19,10 @@ importers:
         version: 4.1.0
       p6-cdk-gha-role:
         specifier: ^0.1.2
-        version: 0.1.2(aws-cdk-lib@2.173.4(constructs@10.4.2))(constructs@10.4.2)
+        version: 0.1.2(aws-cdk-lib@2.174.0(constructs@10.4.2))(constructs@10.4.2)
       p6-cdk-github-oidc-provider:
         specifier: ^0.4.2
-        version: 0.4.2(aws-cdk-lib@2.173.4(constructs@10.4.2))(constructs@10.4.2)
+        version: 0.4.2(aws-cdk-lib@2.174.0(constructs@10.4.2))(constructs@10.4.2)
       source-map-support:
         specifier: ^0.5.21
         version: 0.5.21
@@ -46,8 +46,8 @@ importers:
         specifier: ^8.19.0
         version: 8.19.0(eslint@9.17.0)(typescript@5.7.2)
       aws-cdk:
-        specifier: 2.173.4
-        version: 2.173.4
+        specifier: 2.174.0
+        version: 2.174.0
       eslint:
         specifier: ^9.17.0
         version: 9.17.0
@@ -134,8 +134,8 @@ packages:
   '@aws-cdk/asset-node-proxy-agent-v6@2.1.0':
     resolution: {integrity: sha512-7bY3J8GCVxLupn/kNmpPc5VJz8grx+4RKfnnJiO1LG+uxkZfANZG3RMHhE+qQxxwkyQ9/MfPtTpf748UhR425A==}
 
-  '@aws-cdk/cloud-assembly-schema@38.0.1':
-    resolution: {integrity: sha512-KvPe+NMWAulfNVwY7jenFhzhuLhLqJ/OPy5jx7wUstbjnYnjRVLpUHPU3yCjXFE0J8cuJVdx95BJ4rOs66Pi9w==}
+  '@aws-cdk/cloud-assembly-schema@39.1.37':
+    resolution: {integrity: sha512-qChylPyI545731cXpH8LlosZKKZtkCz4Yo8404zOwAuIbdyR5CLW+RrG10DKyvVHqE8ufcI62astdcQuYY8D9A==}
     bundledDependencies:
       - jsonschema
       - semver
@@ -754,8 +754,8 @@ packages:
     resolution: {integrity: sha512-wvUjBtSGN7+7SjNpq/9M2Tg350UZD3q62IFZLbRAR1bSMlCo1ZaeW+BJ+D090e4hIIZLBcTDWe4Mh4jvUDajzQ==}
     engines: {node: '>= 0.4'}
 
-  aws-cdk-lib@2.173.4:
-    resolution: {integrity: sha512-0reN94TzkWmyVZDDBlYB4qzJUig8wTHEe82YLHlWRUhrU78fT+drVGUr+lYZwwETaZ+8fLdCOl9ULvFNq7iczQ==}
+  aws-cdk-lib@2.174.0:
+    resolution: {integrity: sha512-OHBJcsg0i4KftWVeUzw1AkG7onZWNNM/DH7NQnbDOs0Ap716VvtcTUubUpeFrazDWe9Opfn1essTjv6gaVyHBw==}
     engines: {node: '>= 14.15.0'}
     peerDependencies:
       constructs: ^10.0.0
@@ -772,8 +772,8 @@ packages:
       - yaml
       - mime-types
 
-  aws-cdk@2.173.4:
-    resolution: {integrity: sha512-zgs3xU28VEKIwHwJHu0ZHeoEmwLGnHS2jPCMc2MsIMZu+a7CKyE77Tw6LwJkuuB96BQyqr6xJB3SbeWjXmcFhQ==}
+  aws-cdk@2.174.0:
+    resolution: {integrity: sha512-RN9Y/+MBht0xBwFVKSOwEGBSf/8Q31zwZmRkH9psWHpW24NbB9/frICRqIiWFqiedlNdLdjYkcwP2U4V6Ud6AQ==}
     engines: {node: '>= 14.15.0'}
     hasBin: true
 
@@ -1223,8 +1223,8 @@ packages:
     resolution: {integrity: sha512-brcKcxGnISN2CcVhXJ/kEQlNa0MEfGRtwKtWA16SkqXHKitaKIMrfemJKLKX1YqDU5C/5JY3PvZXd5jEW04e0Q==}
     engines: {node: '>=5.0.0'}
 
-  eslint-plugin-perfectionist@4.5.0:
-    resolution: {integrity: sha512-Dh+6UO50GLRM5z8HMv7HkCy+XUGgDfG8jbTYrqL6A07VBIPzlnM3CMZkovWEWT3mOPzlFTYdyp1bYr+HZTKD6g==}
+  eslint-plugin-perfectionist@4.6.0:
+    resolution: {integrity: sha512-kOswTebUK0LlYExRwqz7YQtvyTUIRsKfp8XrwBBeHGh2e8MBOS6K+7VvG6HpmNckyKySi1I96uPeAlptMFGcRQ==}
     engines: {node: ^18.0.0 || >=20.0.0}
     peerDependencies:
       eslint: '>=8.0.0'
@@ -2836,7 +2836,7 @@ snapshots:
       eslint-plugin-jsonc: 2.18.2(eslint@9.17.0)
       eslint-plugin-n: 17.15.1(eslint@9.17.0)
       eslint-plugin-no-only-tests: 3.3.0
-      eslint-plugin-perfectionist: 4.5.0(eslint@9.17.0)(typescript@5.7.2)
+      eslint-plugin-perfectionist: 4.6.0(eslint@9.17.0)(typescript@5.7.2)
       eslint-plugin-regexp: 2.7.0(eslint@9.17.0)
       eslint-plugin-toml: 0.12.0(eslint@9.17.0)
       eslint-plugin-unicorn: 56.0.1(eslint@9.17.0)
@@ -2874,7 +2874,7 @@ snapshots:
 
   '@aws-cdk/asset-node-proxy-agent-v6@2.1.0': {}
 
-  '@aws-cdk/cloud-assembly-schema@38.0.1': {}
+  '@aws-cdk/cloud-assembly-schema@39.1.37': {}
 
   '@babel/code-frame@7.26.2':
     dependencies:
@@ -3686,15 +3686,15 @@ snapshots:
     dependencies:
       possible-typed-array-names: 1.0.0
 
-  aws-cdk-lib@2.173.4(constructs@10.4.2):
+  aws-cdk-lib@2.174.0(constructs@10.4.2):
     dependencies:
       '@aws-cdk/asset-awscli-v1': 2.2.217
       '@aws-cdk/asset-kubectl-v20': 2.1.3
       '@aws-cdk/asset-node-proxy-agent-v6': 2.1.0
-      '@aws-cdk/cloud-assembly-schema': 38.0.1
+      '@aws-cdk/cloud-assembly-schema': 39.1.37
       constructs: 10.4.2
 
-  aws-cdk@2.173.4:
+  aws-cdk@2.174.0:
     optionalDependencies:
       fsevents: 2.3.2
 
@@ -4235,7 +4235,7 @@ snapshots:
 
   eslint-plugin-no-only-tests@3.3.0: {}
 
-  eslint-plugin-perfectionist@4.5.0(eslint@9.17.0)(typescript@5.7.2):
+  eslint-plugin-perfectionist@4.6.0(eslint@9.17.0)(typescript@5.7.2):
     dependencies:
       '@typescript-eslint/types': 8.19.0
       '@typescript-eslint/utils': 8.19.0(eslint@9.17.0)(typescript@5.7.2)
@@ -5637,14 +5637,14 @@ snapshots:
 
   p-try@2.2.0: {}
 
-  p6-cdk-gha-role@0.1.2(aws-cdk-lib@2.173.4(constructs@10.4.2))(constructs@10.4.2):
+  p6-cdk-gha-role@0.1.2(aws-cdk-lib@2.174.0(constructs@10.4.2))(constructs@10.4.2):
     dependencies:
-      aws-cdk-lib: 2.173.4(constructs@10.4.2)
+      aws-cdk-lib: 2.174.0(constructs@10.4.2)
       constructs: 10.4.2
 
-  p6-cdk-github-oidc-provider@0.4.2(aws-cdk-lib@2.173.4(constructs@10.4.2))(constructs@10.4.2):
+  p6-cdk-github-oidc-provider@0.4.2(aws-cdk-lib@2.174.0(constructs@10.4.2))(constructs@10.4.2):
     dependencies:
-      aws-cdk-lib: 2.173.4(constructs@10.4.2)
+      aws-cdk-lib: 2.174.0(constructs@10.4.2)
       constructs: 10.4.2
 
   package-manager-detector@0.2.8: {}


### PR DESCRIPTION
Upgrades project dependencies. The following changes were made:
```diff
diff --git a/package.json b/package.json
index 006cb95..ee34064 100644
--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
     "@types/node": "22.10.5",
     "@typescript-eslint/eslint-plugin": "^8.19.0",
     "@typescript-eslint/parser": "^8.19.0",
-    "aws-cdk": "2.173.4",
+    "aws-cdk": "2.174.0",
     "eslint": "^9.17.0",
     "eslint-plugin-import": "^2.31.0",
     "jest": "^29.7.0",
@@ -40,7 +40,7 @@
     "node": ">= 22.10.0"
   },
   "dependencies": {
-    "aws-cdk-lib": "2.173.4",
+    "aws-cdk-lib": "2.174.0",
     "constructs": "^10.4.2",
     "js-yaml": "^4.1.0",
     "p6-cdk-gha-role": "^0.1.2",
diff --git a/pnpm-lock.yaml b/pnpm-lock.yaml
index 7092995..e36c68b 100644
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -9,8 +9,8 @@ importers:
   .:
     dependencies:
       aws-cdk-lib:
-        specifier: 2.173.4
-        version: 2.173.4(constructs@10.4.2)
+        specifier: 2.174.0
+        version: 2.174.0(constructs@10.4.2)
       constructs:
         specifier: ^10.4.2
         version: 10.4.2
@@ -19,10 +19,10 @@ importers:
         version: 4.1.0
       p6-cdk-gha-role:
         specifier: ^0.1.2
-        version: 0.1.2(aws-cdk-lib@2.173.4(constructs@10.4.2))(constructs@10.4.2)
+        version: 0.1.2(aws-cdk-lib@2.174.0(constructs@10.4.2))(constructs@10.4.2)
       p6-cdk-github-oidc-provider:
         specifier: ^0.4.2
-        version: 0.4.2(aws-cdk-lib@2.173.4(constructs@10.4.2))(constructs@10.4.2)
+        version: 0.4.2(aws-cdk-lib@2.174.0(constructs@10.4.2))(constructs@10.4.2)
       source-map-support:
         specifier: ^0.5.21
         version: 0.5.21
@@ -46,8 +46,8 @@ importers:
         specifier: ^8.19.0
         version: 8.19.0(eslint@9.17.0)(typescript@5.7.2)
       aws-cdk:
-        specifier: 2.173.4
-        version: 2.173.4
+        specifier: 2.174.0
+        version: 2.174.0
       eslint:
         specifier: ^9.17.0
         version: 9.17.0
@@ -134,8 +134,8 @@ packages:
   '@aws-cdk/asset-node-proxy-agent-v6@2.1.0':
     resolution: {integrity: sha512-7bY3J8GCVxLupn/kNmpPc5VJz8grx+4RKfnnJiO1LG+uxkZfANZG3RMHhE+qQxxwkyQ9/MfPtTpf748UhR425A==}
 
-  '@aws-cdk/cloud-assembly-schema@38.0.1':
-    resolution: {integrity: sha512-KvPe+NMWAulfNVwY7jenFhzhuLhLqJ/OPy5jx7wUstbjnYnjRVLpUHPU3yCjXFE0J8cuJVdx95BJ4rOs66Pi9w==}
+  '@aws-cdk/cloud-assembly-schema@39.1.37':
+    resolution: {integrity: sha512-qChylPyI545731cXpH8LlosZKKZtkCz4Yo8404zOwAuIbdyR5CLW+RrG10DKyvVHqE8ufcI62astdcQuYY8D9A==}
     bundledDependencies:
       - jsonschema
       - semver
@@ -754,8 +754,8 @@ packages:
     resolution: {integrity: sha512-wvUjBtSGN7+7SjNpq/9M2Tg350UZD3q62IFZLbRAR1bSMlCo1ZaeW+BJ+D090e4hIIZLBcTDWe4Mh4jvUDajzQ==}
     engines: {node: '>= 0.4'}
 
-  aws-cdk-lib@2.173.4:
-    resolution: {integrity: sha512-0reN94TzkWmyVZDDBlYB4qzJUig8wTHEe82YLHlWRUhrU78fT+drVGUr+lYZwwETaZ+8fLdCOl9ULvFNq7iczQ==}
+  aws-cdk-lib@2.174.0:
+    resolution: {integrity: sha512-OHBJcsg0i4KftWVeUzw1AkG7onZWNNM/DH7NQnbDOs0Ap716VvtcTUubUpeFrazDWe9Opfn1essTjv6gaVyHBw==}
     engines: {node: '>= 14.15.0'}
     peerDependencies:
       constructs: ^10.0.0
@@ -772,8 +772,8 @@ packages:
       - yaml
       - mime-types
 
-  aws-cdk@2.173.4:
-    resolution: {integrity: sha512-zgs3xU28VEKIwHwJHu0ZHeoEmwLGnHS2jPCMc2MsIMZu+a7CKyE77Tw6LwJkuuB96BQyqr6xJB3SbeWjXmcFhQ==}
+  aws-cdk@2.174.0:
+    resolution: {integrity: sha512-RN9Y/+MBht0xBwFVKSOwEGBSf/8Q31zwZmRkH9psWHpW24NbB9/frICRqIiWFqiedlNdLdjYkcwP2U4V6Ud6AQ==}
     engines: {node: '>= 14.15.0'}
     hasBin: true
 
@@ -1223,8 +1223,8 @@ packages:
     resolution: {integrity: sha512-brcKcxGnISN2CcVhXJ/kEQlNa0MEfGRtwKtWA16SkqXHKitaKIMrfemJKLKX1YqDU5C/5JY3PvZXd5jEW04e0Q==}
     engines: {node: '>=5.0.0'}
 
-  eslint-plugin-perfectionist@4.5.0:
-    resolution: {integrity: sha512-Dh+6UO50GLRM5z8HMv7HkCy+XUGgDfG8jbTYrqL6A07VBIPzlnM3CMZkovWEWT3mOPzlFTYdyp1bYr+HZTKD6g==}
+  eslint-plugin-perfectionist@4.6.0:
+    resolution: {integrity: sha512-kOswTebUK0LlYExRwqz7YQtvyTUIRsKfp8XrwBBeHGh2e8MBOS6K+7VvG6HpmNckyKySi1I96uPeAlptMFGcRQ==}
     engines: {node: ^18.0.0 || >=20.0.0}
     peerDependencies:
       eslint: '>=8.0.0'
@@ -2836,7 +2836,7 @@ snapshots:
       eslint-plugin-jsonc: 2.18.2(eslint@9.17.0)
       eslint-plugin-n: 17.15.1(eslint@9.17.0)
       eslint-plugin-no-only-tests: 3.3.0
-      eslint-plugin-perfectionist: 4.5.0(eslint@9.17.0)(typescript@5.7.2)
+      eslint-plugin-perfectionist: 4.6.0(eslint@9.17.0)(typescript@5.7.2)
       eslint-plugin-regexp: 2.7.0(eslint@9.17.0)
       eslint-plugin-toml: 0.12.0(eslint@9.17.0)
       eslint-plugin-unicorn: 56.0.1(eslint@9.17.0)
@@ -2874,7 +2874,7 @@ snapshots:
 
   '@aws-cdk/asset-node-proxy-agent-v6@2.1.0': {}
 
-  '@aws-cdk/cloud-assembly-schema@38.0.1': {}
+  '@aws-cdk/cloud-assembly-schema@39.1.37': {}
 
   '@babel/code-frame@7.26.2':
     dependencies:
@@ -3686,15 +3686,15 @@ snapshots:
     dependencies:
       possible-typed-array-names: 1.0.0
 
-  aws-cdk-lib@2.173.4(constructs@10.4.2):
+  aws-cdk-lib@2.174.0(constructs@10.4.2):
     dependencies:
       '@aws-cdk/asset-awscli-v1': 2.2.217
       '@aws-cdk/asset-kubectl-v20': 2.1.3
       '@aws-cdk/asset-node-proxy-agent-v6': 2.1.0
-      '@aws-cdk/cloud-assembly-schema': 38.0.1
+      '@aws-cdk/cloud-assembly-schema': 39.1.37
       constructs: 10.4.2
 
-  aws-cdk@2.173.4:
+  aws-cdk@2.174.0:
     optionalDependencies:
       fsevents: 2.3.2
 
@@ -4235,7 +4235,7 @@ snapshots:
 
   eslint-plugin-no-only-tests@3.3.0: {}
 
-  eslint-plugin-perfectionist@4.5.0(eslint@9.17.0)(typescript@5.7.2):
+  eslint-plugin-perfectionist@4.6.0(eslint@9.17.0)(typescript@5.7.2):
     dependencies:
       '@typescript-eslint/types': 8.19.0
       '@typescript-eslint/utils': 8.19.0(eslint@9.17.0)(typescript@5.7.2)
@@ -5637,14 +5637,14 @@ snapshots:
 
   p-try@2.2.0: {}
 
-  p6-cdk-gha-role@0.1.2(aws-cdk-lib@2.173.4(constructs@10.4.2))(constructs@10.4.2):
+  p6-cdk-gha-role@0.1.2(aws-cdk-lib@2.174.0(constructs@10.4.2))(constructs@10.4.2):
     dependencies:
-      aws-cdk-lib: 2.173.4(constructs@10.4.2)
+      aws-cdk-lib: 2.174.0(constructs@10.4.2)
       constructs: 10.4.2
 
-  p6-cdk-github-oidc-provider@0.4.2(aws-cdk-lib@2.173.4(constructs@10.4.2))(constructs@10.4.2):
+  p6-cdk-github-oidc-provider@0.4.2(aws-cdk-lib@2.174.0(constructs@10.4.2))(constructs@10.4.2):
     dependencies:
-      aws-cdk-lib: 2.173.4(constructs@10.4.2)
+      aws-cdk-lib: 2.174.0(constructs@10.4.2)
       constructs: 10.4.2
 
   package-manager-detector@0.2.8: {}
```